### PR TITLE
fix bug regarding the retrieving of the allowed_cidr_blocks attribut

### DIFF
--- a/vpce_interfaces.tf
+++ b/vpce_interfaces.tf
@@ -39,7 +39,7 @@ resource "aws_security_group" "sg" {
       to_port     = ingress.value
       protocol    = "tcp"
       description = format("Allow subnets access %s Endpoint on port %s", upper(each.key), ingress.value)
-      cidr_blocks = lookup(each.value, "cidr_blocks", [])
+      cidr_blocks = lookup(each.value, "allowed_cidr_blocks", [])
     }
   }
 


### PR DESCRIPTION
The generation of inbound rules does not work for the vpc endpoint interface